### PR TITLE
feat: add multilingual support and lang command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,117 +6,106 @@
 ![license](https://img.shields.io/npm/l/@yestarz/ai-code-starter)
 ![node version](https://img.shields.io/node/v/@yestarz/ai-code-starter)
 
-快速启动项目并调用各种 AI 编码工具的统一入口。无需手动切换到项目目录，一条命令即可在任意项目下启动 `CodeX`、`Claude Code`、`Gemini Cli` 等 AI 工具。
+多语言的统一命令行入口，帮助你在任何项目目录中快速唤起常用 AI 编码工具。
 
 </div>
 
-## ✨ 功能特性
+## 📑 目录 / Table of Contents / 目次
+- [中文](#中文)
+- [English](#english)
+- [日本語](#日本語)
 
-- 🗂️ **项目管理**：统一管理常用项目路径，快速切换工作目录
-- 🔧 **CLI 集成**：一键调用各种 AI 编码助手（Codex、ClaudeCode、Gemini 等）
-- 💻 **跨平台支持**：完美适配 Windows、macOS 和 Linux
-- 🎯 **交互式操作**：友好的命令行交互界面，直观易用
-- 🔒 **安全可靠**：自动备份配置文件，操作前二次确认
-- ⚡ **高效便捷**：一条命令即可在指定项目下启动 AI 工具
+---
 
-## 🚀 快速开始
+## 中文
 
-### 安装
+### 简介
+ACS 提供统一的 CLI 入口来管理本地项目，并一键启动 `CodeX`、`Claude Code`、`Gemini` 等 AI 编码工具。现在支持中文、英文、日语界面，可通过 `acs lang` 命令即时切换。
 
+### ✨ 功能特性
+- 🗂️ **项目管理**：集中管理常用项目路径，秒级切换目录
+- 🔧 **CLI 集成**：一条命令唤起多种 AI 助手
+- 💻 **跨平台支持**：兼容 Windows、macOS、Linux
+- 🎯 **交互式体验**：友好的命令行询问流程
+- 🔒 **安全可靠**：自动备份配置，出现异常可快速回滚
+- 🌍 **多语言界面**：支持 `zh` / `en` / `ja`，`acs lang` 即时切换
+
+### 🚀 快速开始
+#### 安装
 ```bash
 # 全局安装
 npm install -g @yestarz/ai-code-starter
 
-# 或者克隆源码本地构建
+# 或者从源码构建
 git clone <repository-url>
-cd ai-cli-starter
+cd ai-code-starter
 npm install
 npm run build
 npm link
 ```
 
-### 首次使用
-
-安装完成后，运行任意命令将自动创建配置文件：
-
+#### 首次使用
+运行任意命令会自动创建 `~/.acs/config.json`：
 ```bash
 acs ls
 ```
 
-这将在 `~/.acs/config.json` 创建默认配置文件。
-
-## 📋 命令指南
-
-### 🔍 查看项目列表
-
+### 📋 命令指南
+#### 🔍 查看项目列表
 ```bash
-# 查看所有项目
 acs list
-# 或使用别名
-acs ls
-
-# 输出 JSON 格式（适合脚本处理）
-acs ls --json
+acs ls --json # 输出 JSON 结果
 ```
 
-### ➕ 添加新项目
-
+#### ➕ 添加新项目
 ```bash
 acs add
 ```
+- 交互式输入项目路径
+- 自动校验路径是否存在
+- 避免重复记录
 
-交互式添加项目：
-- 输入项目路径（支持相对/绝对路径）
-- 自动检测路径有效性
-- 从路径自动提取项目名
-- 检测重复项目并提供确认选项
-
-### ❌ 删除项目
-
+#### ❌ 删除项目
 ```bash
 acs remove
-# 或使用别名
 acs rm
 ```
+- 多选删除
+- 二次确认
+- 失败自动回滚
 
-安全删除流程：
-- 多选要删除的项目
-- 二次确认避免误操作
-- 自动创建配置备份
-- 操作失败时自动回滚
-
-### 🚀 启动 AI 工具
-
+#### 🚀 启动 AI 工具
 ```bash
 acs code
 ```
+1. 选择项目
+2. 选择 CLI 工具
+3. 自动切换目录并执行命令
 
-智能工作流：
-1. 选择目标项目
-2. 选择 AI 编码工具
-3. 自动切换到项目目录
-4. 启动选定的 AI 工具
-5. 完整继承输入输出，支持交互
+#### 🌐 切换显示语言
+```bash
+# 直接指定语言代码
+acs lang en
 
-## ⚙️ 配置文件
+# 或进入交互式选择
+acs lang
+```
+支持 `zh`（中文）、`en`（English）、`ja`（日本語）。
 
-配置文件位于 `~/.acs/config.json`，结构如下：
-
+### ⚙️ 配置文件
+配置文件位于 `~/.acs/config.json`：
 ```json
 {
+  "language": "zh",
   "projects": [
     {
       "name": "my-web-app",
       "path": "/Users/username/code/my-web-app"
-    },
-    {
-      "name": "api-server", 
-      "path": "D:\\code\\projects\\api-server"
     }
   ],
   "cli": [
     {
-      "name": "Codex",
+      "name": "CodeX",
       "command": "codex"
     },
     {
@@ -125,162 +114,221 @@ acs code
     },
     {
       "name": "Gemini Cli",
-      "command": "gemin"
+      "command": "gemini"
     }
   ]
 }
 ```
+- `language`：CLI 显示语言，默认 `zh`
+- `projects`：项目列表，路径会自动规范化
+- `cli`：可用的 AI 工具与其命令
 
-### 配置说明
-
-- **projects**: 项目列表
-  - `name`: 项目显示名称
-  - `path`: 项目绝对路径（自动规范化）
-
-- **cli**: AI 工具列表  
-  - `name`: 工具显示名称
-  - `command`: 执行命令（支持带参数）
-
-## 💡 使用示例
-
-### 典型工作流
-
+### 💡 示例流程
 ```bash
-# 1. 添加项目
 $ acs add
 ? 请输入项目路径 › /Users/dev/my-react-app
 ✅ 添加成功：my-react-app -> /Users/dev/my-react-app
 
-# 2. 查看项目列表
 $ acs ls
 共 1 个项目：
 1. my-react-app -> /Users/dev/my-react-app
 
-# 3. 在项目中启动 AI 工具
-$ acs code
-? 选择项目 › my-react-app (/Users/dev/my-react-app)
-? 选择 CLI 工具 › Cursor
-正在启动 Cursor...
+$ acs lang en
+Language switched to English
 ```
 
-### 批量管理
-
+### 🔧 开发与测试
 ```bash
-# 删除多个项目
-$ acs rm
-? 选择要删除的项目 › 
-  ◯ project-1
-  ◉ old-project
-  ◉ temp-project
-? 确认删除选中的 2 个项目？ › Yes
-✅ 成功删除 2 个项目
+npm run dev   # 开发模式
+npm run build # 打包
+npm test      # 运行测试
+acs ls --verbose # 显示调试日志
 ```
-
-## 🔧 开发与测试
-
-### 开发环境
-
-```bash
-# 开发模式（热重载）
-npm run dev
-
-# 构建项目
-npm run build
-
-# 运行测试
-npm test
-
-# 启用详细日志
-acs ls --verbose
-```
-
-### 测试覆盖
-
-项目包含完整的单元测试和集成测试：
-- ✅ 配置文件读写
-- ✅ 项目增删查改
-- ✅ 跨平台路径处理
-- ✅ 错误处理与回滚
-- ✅ 命令行参数解析
-
-## ❓ 常见问题
-
-### 安装问题
-
-**Q: `npm link` 需要管理员权限怎么办？**
-```bash
-# Windows: 以管理员身份运行终端
-# 或使用 npx 运行
-npx @yestarz/ai-code-starter ls
-```
-
-**Q: 命令找不到怎么办？**
-```bash
-# 检查全局安装
-npm list -g @yestarz/ai-code-starter
-
-# 重新链接
-npm unlink -g @yestarz/ai-code-starter
-npm link
-```
-
-### 路径问题
-
-**Q: Windows 路径格式如何输入？**
-
-支持多种格式，工具会自动规范化：
-- `C:\code\project` ✅
-- `C:/code/project` ✅  
-- `C:\\code\\project` ✅
-
-**Q: 相对路径支持吗？**
-
-支持，但会自动转换为绝对路径存储。
-
-### 工具配置
-
-**Q: CLI 列表为空怎么办？**
-
-手动编辑配置文件添加 AI 工具：
-```bash
-# 打开配置文件
-code ~/.acs/config.json
-
-# 或查看配置文件位置
-acs ls --verbose
-```
-
-**Q: 如何添加自定义 AI 工具？**
-
-在 `cli` 数组中添加新条目：
-```json
-{
-  "name": "My Custom AI",
-  "command": "my-ai-tool --interactive"
-}
-```
-
-## 📝 许可证
-
-MIT License - 详见 [LICENSE](LICENSE) 文件
-
-## 🤝 贡献指南
-
-欢迎提交 Issue 和 Pull Request！
-
-1. Fork 本仓库
-2. 创建特性分支 (`git checkout -b feature/amazing-feature`)
-3. 提交变更 (`git commit -m 'feat: 添加某个牛逼功能'`)
-4. 推送到分支 (`git push origin feature/amazing-feature`)
-5. 提交 Pull Request
 
 ---
 
-<div align="center">
+## English
 
-如果这个工具对你有帮助，请给个 ⭐ Star 支持一下！
+### Overview
+ACS is a multi-language CLI that manages your project list and launches AI coding assistants such as `CodeX`, `Claude Code`, and `Gemini`. Use `acs lang` to switch between Chinese, English, and Japanese interfaces instantly.
 
-Made with ❤️ for developers
+### ✨ Features
+- 🗂️ **Project management** for frequently used paths
+- 🔧 **AI CLI integration** with one command
+- 💻 **Cross-platform** support (Windows/macOS/Linux)
+- 🎯 **Interactive prompts** for smooth workflows
+- 🔒 **Safe operations** with automatic config backups
+- 🌍 **Multi-language UI** via `acs lang`
 
-</div>
+### 🚀 Quick Start
+#### Install
+```bash
+npm install -g @yestarz/ai-code-starter
+# or build from source
+```
 
+#### First run
+```bash
+acs ls
+```
+The command initializes `~/.acs/config.json` if it does not exist.
+
+### 📋 Command Guide
+#### 🔍 List projects
+```bash
+acs list
+acs ls --json
+```
+
+#### ➕ Add a project
+```bash
+acs add
+```
+Validates the path, prevents duplicates, and derives the project name automatically.
+
+#### ❌ Remove projects
+```bash
+acs remove
+acs rm
+```
+Multi-select with confirmation and automatic rollback.
+
+#### 🚀 Launch an AI tool
+```bash
+acs code
+```
+Choose a project, select a CLI, and run it in the project directory.
+
+#### 🌐 Switch language
+```bash
+acs lang en   # switch directly
+acs lang      # interactive picker
+```
+Available codes: `zh`, `en`, `ja`.
+
+### ⚙️ Configuration
+`~/.acs/config.json` example:
+```json
+{
+  "language": "en",
+  "projects": [],
+  "cli": [
+    { "name": "CodeX", "command": "codex" },
+    { "name": "Claude Code", "command": "claude" },
+    { "name": "Gemini Cli", "command": "gemini" }
+  ]
+}
+```
+- `language`: current UI language (defaults to `zh`)
+- `projects`: tracked project list
+- `cli`: available AI tools and their executable commands
+
+### 💡 Example
+```bash
+$ acs add
+? Enter project path › /Users/dev/my-react-app
+Added: my-react-app -> /Users/dev/my-react-app
+
+$ acs lang ja
+言語を 日本語 に切り替えました
+```
+
+### 🔧 Development & Testing
+```bash
+npm run dev
+npm run build
+npm test
+acs ls --verbose
+```
+
+---
+
+## 日本語
+
+### 概要
+ACS は複数言語対応の CLI で、プロジェクト一覧の管理と `CodeX`・`Claude Code`・`Gemini` などの AI ツール起動を一元化します。`acs lang` で日本語・英語・中国語を切り替えられます。
+
+### ✨ 特長
+- 🗂️ **プロジェクト管理**：よく使うディレクトリを素早く呼び出し
+- 🔧 **AI ツール統合**：1 コマンドで好みの CLI を起動
+- 💻 **マルチプラットフォーム**対応
+- 🎯 **対話的な操作**で迷わず利用可能
+- 🔒 **安全設計**：設定ファイルを自動バックアップ
+- 🌍 **多言語 UI**：`acs lang` で即時切替
+
+### 🚀 はじめに
+#### インストール
+```bash
+npm install -g @yestarz/ai-code-starter
+```
+
+#### 初回実行
+```bash
+acs ls
+```
+実行すると `~/.acs/config.json` が生成されます。
+
+### 📋 コマンド
+#### 🔍 プロジェクト一覧
+```bash
+acs list
+acs ls --json
+```
+
+#### ➕ プロジェクト追加
+```bash
+acs add
+```
+パスの検証と重複チェックを自動で行います。
+
+#### ❌ プロジェクト削除
+```bash
+acs remove
+acs rm
+```
+複数選択・確認ダイアログ・失敗時のロールバックに対応。
+
+#### 🚀 AI ツール起動
+```bash
+acs code
+```
+プロジェクトと CLI を選択して実行します。
+
+#### 🌐 表示言語の変更
+```bash
+acs lang ja
+acs lang
+```
+利用可能: `zh` / `en` / `ja`。
+
+### ⚙️ 設定ファイル
+`~/.acs/config.json` の例：
+```json
+{
+  "language": "ja",
+  "projects": [],
+  "cli": [
+    { "name": "CodeX", "command": "codex" },
+    { "name": "Claude Code", "command": "claude" },
+    { "name": "Gemini Cli", "command": "gemini" }
+  ]
+}
+```
+
+### 💡 利用例
+```bash
+$ acs add
+? プロジェクトのパスを入力 › /Users/dev/my-react-app
+追加しました: my-react-app -> /Users/dev/my-react-app
+
+$ acs lang zh
+语言已切换为 中文
+```
+
+### 🔧 開発・テスト
+```bash
+npm run dev
+npm run build
+npm test
+acs ls --verbose
+```

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -14,24 +14,27 @@ export async function runAdd(
   context: CommandContext
 ): Promise<CommandResult> {
   const config = readConfig();
+  const { t } = context;
 
   const { inputPath } = await inquirer.prompt<{ inputPath: string }>([
     {
       type: "input",
       name: "inputPath",
-      message: "请输入项目路径",
+      message: t("add.promptPath"),
       validate(value: string) {
         try {
           const normalized = normalizePath(value);
           if (!fs.existsSync(normalized)) {
-            return "路径不存在，请重新输入";
+            return t("add.validate.notExists");
           }
           if (!fs.statSync(normalized).isDirectory()) {
-            return "目标不是目录";
+            return t("add.validate.notDirectory");
           }
           return true;
         } catch (error) {
-          return (error as Error).message;
+          return t("add.validate.unexpected", {
+            message: (error as Error).message,
+          });
         }
       },
     },
@@ -45,8 +48,8 @@ export async function runAdd(
 
   if (sameName || samePath) {
     const warningMessage = samePath
-      ? "该路径已存在于配置中，确定仍要重复添加吗？"
-      : "存在同名项目，是否继续？";
+      ? t("add.duplicatePath")
+      : t("add.duplicateName");
     const { confirmDuplicate } = await inquirer.prompt<{ confirmDuplicate: boolean }>([
       {
         type: "confirm",
@@ -57,7 +60,7 @@ export async function runAdd(
     ]);
 
     if (!confirmDuplicate) {
-      context.logger.info("已取消添加操作");
+      context.logger.info(t("add.cancelled"));
       return { code: 0 };
     }
   }
@@ -77,7 +80,10 @@ export async function runAdd(
 
   context.logger.info(
     green(
-      `添加成功：${bold(projectName)} -> ${formatPathForDisplay(absolutePath)}`
+      t("add.success", {
+        name: bold(projectName),
+        path: formatPathForDisplay(absolutePath),
+      })
     )
   );
 

--- a/src/commands/lang.ts
+++ b/src/commands/lang.ts
@@ -1,0 +1,79 @@
+import inquirer from "inquirer";
+import { readConfig, writeConfig } from "../config";
+import { CliArguments, CommandContext, CommandResult } from "../types";
+import {
+  createTranslator,
+  getLanguageDisplayName,
+  isSupportedLanguage,
+  supportedLanguages,
+  type Language,
+} from "../i18n";
+
+export async function runLang(
+  args: CliArguments,
+  context: CommandContext
+): Promise<CommandResult> {
+  const { t } = context;
+  const config = readConfig();
+  const currentLanguage = config.language;
+
+  let targetLanguage: Language | undefined;
+  const [providedLanguage] = args.positional;
+  if (providedLanguage) {
+    if (!isSupportedLanguage(providedLanguage)) {
+      context.logger.error(
+        t("lang.invalid", {
+          input: providedLanguage,
+          supported: supportedLanguages.join(", "),
+        })
+      );
+      return { code: 1 };
+    }
+    targetLanguage = providedLanguage;
+  } else {
+    const choices = supportedLanguages.map((language) => {
+      const displayName = getLanguageDisplayName(language, t);
+      const label = `${displayName} (${language})`;
+      const suffix =
+        language === currentLanguage ? ` ${t("lang.choiceCurrent")}` : "";
+      return {
+        name: `${label}${suffix}`,
+        value: language,
+      };
+    });
+
+    const { selectedLanguage } = await inquirer.prompt<{
+      selectedLanguage: Language;
+    }>([
+      {
+        type: "list",
+        name: "selectedLanguage",
+        message: t("lang.prompt"),
+        choices,
+        default: currentLanguage,
+      },
+    ]);
+
+    targetLanguage = selectedLanguage;
+  }
+
+  if (targetLanguage === currentLanguage) {
+    context.logger.info(
+      t("lang.already", {
+        language: getLanguageDisplayName(currentLanguage, t),
+      })
+    );
+    return { code: 0 };
+  }
+
+  writeConfig({ ...config, language: targetLanguage });
+
+  const updatedTranslator = createTranslator(targetLanguage);
+  context.logger.info(
+    updatedTranslator("lang.updated", {
+      language: getLanguageDisplayName(targetLanguage, updatedTranslator),
+    })
+  );
+
+  return { code: 0 };
+}

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -12,6 +12,7 @@ export async function runList(
 ): Promise<CommandResult> {
   const config = readConfig();
   const projects = config.projects;
+  const { t } = context;
 
   if (args.flags.json) {
     console.log(JSON.stringify(projects, null, 2));
@@ -19,21 +20,22 @@ export async function runList(
   }
 
   if (!projects.length) {
-    console.log(gray("暂无项目。可通过 `acs add` 添加新的项目。"));
+    console.log(gray(t("list.empty")));
     return { code: 0 };
   }
 
-  console.log(bold(cyan(`共 ${projects.length} 个项目：`)));
+  console.log(bold(cyan(t("list.summary", { count: projects.length }))));
   projects.forEach((project, index) => {
-    console.log(
-      `${index + 1}. ${bold(project.name)} -> ${gray(
-        formatPathForDisplay(project.path)
-      )}`
-    );
+    const entry = t("list.entry", {
+      index: index + 1,
+      name: bold(project.name),
+      path: gray(formatPathForDisplay(project.path)),
+    });
+    console.log(entry);
   });
 
   if (context.verbose) {
-    context.logger.debug(`当前配置包含 ${projects.length} 条记录`);
+    context.logger.debug(t("list.debugCount", { count: projects.length }));
   }
 
   return { code: 0 };

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -13,9 +13,10 @@ export async function runRemove(
 ): Promise<CommandResult> {
   const config = readConfig();
   const { projects } = config;
+  const { t } = context;
 
   if (!projects.length) {
-    context.logger.warn("当前没有可删除的项目");
+    context.logger.warn(t("remove.none"));
     return { code: 0 };
   }
 
@@ -28,13 +29,13 @@ export async function runRemove(
     {
       type: "checkbox",
       name: "selectedPaths",
-      message: "选择要删除的项目",
+      message: t("remove.promptSelect"),
       choices,
     },
   ]);
 
   if (!selectedPaths.length) {
-    context.logger.warn("未选择任何项目，操作已取消");
+    context.logger.warn(t("remove.cancelledNoSelection"));
     return { code: 0 };
   }
 
@@ -42,13 +43,13 @@ export async function runRemove(
     {
       type: "confirm",
       name: "confirm",
-      message: `确认删除 ${selectedPaths.length} 个项目吗？`,
+      message: t("remove.promptConfirm", { count: selectedPaths.length }),
       default: false,
     },
   ]);
 
   if (!confirm) {
-    context.logger.info("已取消删除操作");
+    context.logger.info(t("remove.cancelled"));
     return { code: 0 };
   }
 
@@ -62,9 +63,10 @@ export async function runRemove(
   writeConfig({ ...config, projects: remaining });
   context.logger.info(
     green(
-      `已删除 ${removedProjects.length} 个项目：${removedProjects
-        .map((item) => item.name)
-        .join(", ")}`
+      t("remove.success", {
+        count: removedProjects.length,
+        names: removedProjects.map((item) => item.name).join(", "),
+      })
     )
   );
 
@@ -72,7 +74,7 @@ export async function runRemove(
     const removedNames = removedProjects
       .map((item) => `${item.name}(${formatPathForDisplay(item.path)})`)
       .join(", ");
-    context.logger.debug(`删除的项目详情：${removedNames}`);
+    context.logger.debug(t("remove.debugDetails", { details: removedNames }));
   }
 
   return { code: 0 };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,255 @@
+export type Language = "zh" | "en" | "ja";
+
+type MessageCatalog = Record<Language, Record<string, string>>;
+
+export type MessageValues = Record<string, string | number>;
+
+export type Translator = (key: MessageKey, values?: MessageValues) => string;
+
+const messageCatalog: MessageCatalog = {
+  zh: {
+    "command.list.description": "列出已登记的项目",
+    "command.remove.description": "删除一个或多个项目",
+    "command.code.description": "在项目目录下执行指定 CLI",
+    "command.add.description": "添加新的项目记录",
+    "command.lang.description": "选择 CLI 显示语言",
+    "help.usage": "用法：acs <命令> [选项]",
+    "help.availableCommands": "可用命令：",
+    "help.alias": "（别名: {aliases}）",
+    "help.commonOptions": "常用选项：",
+    "help.option.verbose": "--verbose/-v  输出调试信息",
+    "help.option.json": "--json        列表命令输出原始 JSON",
+    "help.option.help": "--help/-h     查看帮助信息",
+    "errors.unknownCommand": "未知命令：{name}",
+    "errors.commandFailed": "命令执行失败：{message}",
+    "errors.unhandled": "未捕获的错误：{message}",
+    "errors.config.readFailed": "配置文件 {path} 无法读取，请手动检查",
+    "errors.config.invalid": "配置文件格式错误：{errors}",
+    "errors.config.writeFailed": "写入配置失败：{message}",
+    "errors.config.noDetails": "未提供详细信息",
+    "errors.config.rootPath": "配置根",
+    "errors.config.issue": "{path}: {message}",
+    "errors.projectNameRequired": "项目名称不能为空",
+    "errors.projectPathRequired": "项目路径不能为空",
+    "errors.cliNameRequired": "CLI 名称不能为空",
+    "errors.cliCommandRequired": "CLI 命令不能为空",
+    "list.empty": "暂无项目。可通过 `acs add` 添加新的项目。",
+    "list.summary": "共 {count} 个项目：",
+    "list.entry": "{index}. {name} -> {path}",
+    "list.debugCount": "当前配置包含 {count} 条记录",
+    "remove.none": "当前没有可删除的项目",
+    "remove.promptSelect": "选择要删除的项目",
+    "remove.promptConfirm": "确认删除 {count} 个项目吗？",
+    "remove.cancelledNoSelection": "未选择任何项目，操作已取消",
+    "remove.cancelled": "已取消删除操作",
+    "remove.success": "已删除 {count} 个项目：{names}",
+    "remove.debugDetails": "删除的项目详情：{details}",
+    "add.promptPath": "请输入项目路径",
+    "add.validate.notExists": "路径不存在，请重新输入",
+    "add.validate.notDirectory": "目标不是目录",
+    "add.validate.unexpected": "验证路径时出现错误：{message}",
+    "add.duplicatePath": "该路径已存在于配置中，确定仍要重复添加吗？",
+    "add.duplicateName": "存在同名项目，是否继续？",
+    "add.cancelled": "已取消添加操作",
+    "add.success": "添加成功：{name} -> {path}",
+    "code.noProjects": "当前没有项目，请先通过 `acs add` 添加。",
+    "code.noCli": "CLI 列表为空，请编辑 {path} 添加可用 CLI。",
+    "code.promptProject": "选择需要进入的项目",
+    "code.projectMissing": "选择的项目不存在，可能配置已变更。",
+    "code.promptCli": "选择要运行的 CLI",
+    "code.execute": "将在 {project} 中执行 {cli}",
+    "code.projectMissingSuffix": " [路径不存在]",
+    "code.projectMissingLabel": "路径不存在",
+    "spawn.verbose": "执行命令: {command}{args}{location}",
+    "spawn.signal": "子进程因信号 {signal} 终止",
+    "spawn.missingCommand": "未提供可执行命令",
+    "lang.prompt": "选择 CLI 显示语言",
+    "lang.invalid": "不支持的语言：{input}。可选值：{supported}",
+    "lang.already": "当前已使用 {language}",
+    "lang.updated": "语言已切换为 {language}",
+    "lang.choiceCurrent": "（当前）",
+    "language.zh": "中文",
+    "language.en": "英语",
+    "language.ja": "日语",
+    "logger.debugLabel": "调试",
+  },
+  en: {
+    "command.list.description": "List registered projects",
+    "command.remove.description": "Remove one or more projects",
+    "command.code.description": "Run a CLI inside the project directory",
+    "command.add.description": "Add a new project entry",
+    "command.lang.description": "Select CLI language",
+    "help.usage": "Usage: acs <command> [options]",
+    "help.availableCommands": "Available commands:",
+    "help.alias": "(alias: {aliases})",
+    "help.commonOptions": "Common options:",
+    "help.option.verbose": "--verbose/-v  Enable verbose logging",
+    "help.option.json": "--json        Print raw JSON for list",
+    "help.option.help": "--help/-h     Show this help message",
+    "errors.unknownCommand": "Unknown command: {name}",
+    "errors.commandFailed": "Command failed: {message}",
+    "errors.unhandled": "Unhandled error: {message}",
+    "errors.config.readFailed": "Failed to read config file {path}. Please check it manually.",
+    "errors.config.invalid": "Invalid config file format: {errors}",
+    "errors.config.writeFailed": "Failed to write config: {message}",
+    "errors.config.noDetails": "No additional details",
+    "errors.config.rootPath": "root",
+    "errors.config.issue": "{path}: {message}",
+    "errors.projectNameRequired": "Project name is required",
+    "errors.projectPathRequired": "Project path is required",
+    "errors.cliNameRequired": "CLI name is required",
+    "errors.cliCommandRequired": "CLI command is required",
+    "list.empty": "No projects yet. Run `acs add` to register one.",
+    "list.summary": "Total {count} project(s):",
+    "list.entry": "{index}. {name} -> {path}",
+    "list.debugCount": "Config contains {count} record(s)",
+    "remove.none": "There are no projects to remove.",
+    "remove.promptSelect": "Select projects to remove",
+    "remove.promptConfirm": "Remove {count} project(s)?",
+    "remove.cancelledNoSelection": "No project selected. Operation cancelled.",
+    "remove.cancelled": "Removal cancelled.",
+    "remove.success": "Removed {count} project(s): {names}",
+    "remove.debugDetails": "Removed project details: {details}",
+    "add.promptPath": "Enter project path",
+    "add.validate.notExists": "Path not found. Please try again.",
+    "add.validate.notDirectory": "The target is not a directory.",
+    "add.validate.unexpected": "Failed to validate the path: {message}",
+    "add.duplicatePath": "This path already exists in the config. Add it again?",
+    "add.duplicateName": "A project with the same name exists. Continue?",
+    "add.cancelled": "Add operation cancelled.",
+    "add.success": "Added: {name} -> {path}",
+    "code.noProjects": "No projects available. Run `acs add` first.",
+    "code.noCli": "CLI list is empty. Edit {path} to add available tools.",
+    "code.promptProject": "Select a project",
+    "code.projectMissing": "Selected project is missing. The config may have changed.",
+    "code.promptCli": "Select a CLI to run",
+    "code.execute": "Running {cli} inside {project}",
+    "code.projectMissingSuffix": " [missing]",
+    "code.projectMissingLabel": "missing",
+    "spawn.verbose": "Executing: {command}{args}{location}",
+    "spawn.signal": "Child process exited due to signal {signal}",
+    "spawn.missingCommand": "No executable command provided",
+    "lang.prompt": "Choose CLI language",
+    "lang.invalid": "Unsupported language: {input}. Supported values: {supported}",
+    "lang.already": "{language} is already active.",
+    "lang.updated": "Language switched to {language}",
+    "lang.choiceCurrent": "(current)",
+    "language.zh": "Chinese",
+    "language.en": "English",
+    "language.ja": "Japanese",
+    "logger.debugLabel": "debug",
+  },
+  ja: {
+    "command.list.description": "登録済みのプロジェクトを一覧表示",
+    "command.remove.description": "プロジェクトを削除",
+    "command.code.description": "プロジェクトディレクトリで CLI を実行",
+    "command.add.description": "新しいプロジェクトを追加",
+    "command.lang.description": "CLI の表示言語を選択",
+    "help.usage": "使い方: acs <コマンド> [オプション]",
+    "help.availableCommands": "利用可能なコマンド:",
+    "help.alias": "（別名: {aliases}）",
+    "help.commonOptions": "主なオプション:",
+    "help.option.verbose": "--verbose/-v  詳細ログを表示",
+    "help.option.json": "--json        list コマンドで JSON を出力",
+    "help.option.help": "--help/-h     ヘルプを表示",
+    "errors.unknownCommand": "不明なコマンドです: {name}",
+    "errors.commandFailed": "コマンドの実行に失敗しました: {message}",
+    "errors.unhandled": "未処理のエラー: {message}",
+    "errors.config.readFailed": "設定ファイル {path} を読み込めません。手動で確認してください。",
+    "errors.config.invalid": "設定ファイルの形式が正しくありません: {errors}",
+    "errors.config.writeFailed": "設定ファイルの書き込みに失敗しました: {message}",
+    "errors.config.noDetails": "詳細情報はありません",
+    "errors.config.rootPath": "ルート",
+    "errors.config.issue": "{path}: {message}",
+    "errors.projectNameRequired": "プロジェクト名は必須です",
+    "errors.projectPathRequired": "プロジェクトパスは必須です",
+    "errors.cliNameRequired": "CLI 名は必須です",
+    "errors.cliCommandRequired": "CLI コマンドは必須です",
+    "list.empty": "プロジェクトがありません。`acs add` で追加してください。",
+    "list.summary": "合計 {count} 件のプロジェクト:",
+    "list.entry": "{index}. {name} -> {path}",
+    "list.debugCount": "設定には {count} 件のレコードが含まれています",
+    "remove.none": "削除できるプロジェクトがありません",
+    "remove.promptSelect": "削除するプロジェクトを選択",
+    "remove.promptConfirm": "{count} 件のプロジェクトを削除しますか?",
+    "remove.cancelledNoSelection": "プロジェクトが選択されていません。操作を中止しました。",
+    "remove.cancelled": "削除を中止しました",
+    "remove.success": "{count} 件のプロジェクトを削除しました: {names}",
+    "remove.debugDetails": "削除したプロジェクトの詳細: {details}",
+    "add.promptPath": "プロジェクトのパスを入力",
+    "add.validate.notExists": "パスが見つかりません。再入力してください。",
+    "add.validate.notDirectory": "ディレクトリではありません。",
+    "add.validate.unexpected": "パスの検証に失敗しました: {message}",
+    "add.duplicatePath": "このパスは既に登録されています。続行しますか?",
+    "add.duplicateName": "同名のプロジェクトが存在します。続行しますか?",
+    "add.cancelled": "追加を中止しました",
+    "add.success": "追加しました: {name} -> {path}",
+    "code.noProjects": "プロジェクトがありません。まず `acs add` を実行してください。",
+    "code.noCli": "CLI リストが空です。{path} を編集してツールを追加してください。",
+    "code.promptProject": "プロジェクトを選択",
+    "code.projectMissing": "選択したプロジェクトが見つかりません。設定が変更された可能性があります。",
+    "code.promptCli": "実行する CLI を選択",
+    "code.execute": "{project} で {cli} を実行します",
+    "code.projectMissingSuffix": " [パスが存在しません]",
+    "code.projectMissingLabel": "パスが存在しません",
+    "spawn.verbose": "実行中: {command}{args}{location}",
+    "spawn.signal": "子プロセスがシグナル {signal} により終了しました",
+    "spawn.missingCommand": "実行可能なコマンドが指定されていません",
+    "lang.prompt": "CLI の表示言語を選択",
+    "lang.invalid": "サポートされていない言語です: {input}。利用可能: {supported}",
+    "lang.already": "{language} はすでに利用中です",
+    "lang.updated": "言語を {language} に切り替えました",
+    "lang.choiceCurrent": "（現在）",
+    "language.zh": "中国語",
+    "language.en": "英語",
+    "language.ja": "日本語",
+    "logger.debugLabel": "デバッグ",
+  },
+};
+
+export type MessageKey = keyof typeof messageCatalog.zh;
+
+function resolveTemplate(language: Language, key: MessageKey): string {
+  const catalog = messageCatalog[language];
+  return catalog[key] ?? messageCatalog.zh[key] ?? key;
+}
+
+function formatTemplate(template: string, values?: MessageValues): string {
+  if (!values) {
+    return template;
+  }
+  return template.replace(/\{(\w+)\}/g, (fullMatch, token) => {
+    if (Object.prototype.hasOwnProperty.call(values, token)) {
+      const value = values[token];
+      return value === undefined || value === null ? "" : String(value);
+    }
+    return fullMatch;
+  });
+}
+
+export function translate(
+  language: Language,
+  key: MessageKey,
+  values?: MessageValues
+): string {
+  const template = resolveTemplate(language, key);
+  return formatTemplate(template, values);
+}
+
+export function createTranslator(language: Language): Translator {
+  return (key, values) => translate(language, key, values);
+}
+
+export function isSupportedLanguage(value: string | undefined | null): value is Language {
+  if (!value) {
+    return false;
+  }
+  return (messageCatalog as MessageCatalog)[value as Language] !== undefined;
+}
+
+export const supportedLanguages: Language[] = Object.keys(messageCatalog) as Language[];
+
+export function getLanguageDisplayName(language: Language, translator: Translator): string {
+  return translator(`language.${language}` as MessageKey);
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 /**
  * CLI 入口，负责解析命令、处理全局选项并分发到具体命令实现。
  */
-import { bold, cyan, gray, red } from "colorette";
+import { bold, gray, red } from "colorette";
 import pkg from "../package.json";
-import { createLogger } from "./utils/logger";
+import { createLogger, type Logger } from "./utils/logger";
 import {
   CliArguments,
   CommandContext,
@@ -14,11 +14,19 @@ import { runList } from "./commands/list";
 import { runRemove } from "./commands/remove";
 import { runCode } from "./commands/code";
 import { runAdd } from "./commands/add";
+import { runLang } from "./commands/lang";
+import { readConfig, ConfigError, type ConfigErrorIssue } from "./config";
+import {
+  createTranslator,
+  type MessageKey,
+  type Translator,
+  type Language,
+} from "./i18n";
 
 interface CommandDefinition {
   name: string;
   aliases: string[];
-  description: string;
+  descriptionKey: MessageKey;
   handler: CommandHandler;
 }
 
@@ -26,26 +34,32 @@ const commandDefinitions: CommandDefinition[] = [
   {
     name: "list",
     aliases: ["ls"],
-    description: "列出已登记的项目",
+    descriptionKey: "command.list.description",
     handler: runList,
   },
   {
     name: "remove",
     aliases: ["rm"],
-    description: "删除一个或多个项目",
+    descriptionKey: "command.remove.description",
     handler: runRemove,
   },
   {
     name: "code",
     aliases: [],
-    description: "在项目目录下执行指定 CLI",
+    descriptionKey: "command.code.description",
     handler: runCode,
   },
   {
     name: "add",
     aliases: [],
-    description: "添加新的项目记录",
+    descriptionKey: "command.add.description",
     handler: runAdd,
+  },
+  {
+    name: "lang",
+    aliases: [],
+    descriptionKey: "command.lang.description",
+    handler: runLang,
   },
 ];
 
@@ -113,20 +127,79 @@ function findCommand(name: string): CommandDefinition | undefined {
   );
 }
 
-function showHelp(): void {
+function showHelp(translator: Translator): void {
   console.log(bold(`acs ${pkg.version}`));
-  console.log("用法：acs <命令> [选项]");
-  console.log("可用命令：");
+  console.log(translator("help.usage"));
+  console.log(translator("help.availableCommands"));
   commandDefinitions.forEach((command) => {
     const aliasDisplay = command.aliases.length
-      ? gray(` (别名: ${command.aliases.join(", ")})`)
+      ? gray(
+          translator("help.alias", {
+            aliases: command.aliases.join(", "),
+          })
+        )
       : "";
-    console.log(`  ${bold(command.name)}${aliasDisplay} - ${command.description}`);
+    console.log(
+      `  ${bold(command.name)}${aliasDisplay} - ${translator(
+        command.descriptionKey
+      )}`
+    );
   });
-  console.log("\n常用选项：");
-  console.log("  --verbose/-v  输出调试信息");
-  console.log("  --json        列表命令输出原始 JSON");
-  console.log("  --help/-h     查看帮助信息");
+  console.log("");
+  console.log(translator("help.commonOptions"));
+  console.log(`  ${translator("help.option.verbose")}`);
+  console.log(`  ${translator("help.option.json")}`);
+  console.log(`  ${translator("help.option.help")}`);
+}
+
+function formatConfigIssues(
+  issues: ConfigErrorIssue[],
+  translator: Translator
+): string {
+  if (!issues.length) {
+    return translator("errors.config.noDetails");
+  }
+  return issues
+    .map((issue) =>
+      translator("errors.config.issue", {
+        path: issue.path || translator("errors.config.rootPath"),
+        message: translator(issue.messageKey as MessageKey),
+      })
+    )
+    .join("; ");
+}
+
+function handleConfigError(
+  error: ConfigError,
+  logger: Logger,
+  translator: Translator
+): void {
+  const { details } = error;
+  switch (error.code) {
+    case "read_failed":
+      logger.error(
+        translator("errors.config.readFailed", { path: details?.path ?? "" })
+      );
+      break;
+    case "invalid_format": {
+      const formatted = details?.issues
+        ? formatConfigIssues(details.issues, translator)
+        : translator("errors.config.noDetails");
+      logger.error(
+        translator("errors.config.invalid", { errors: formatted })
+      );
+      break;
+    }
+    case "write_failed": {
+      const message =
+        details?.errorMessage ??
+        (error.cause instanceof Error ? error.cause.message : "");
+      logger.error(translator("errors.config.writeFailed", { message }));
+      break;
+    }
+    default:
+      logger.error(error.message);
+  }
 }
 
 async function executeCommand(
@@ -144,10 +217,34 @@ async function main(): Promise<void> {
   const helpFlag = parsed.flags.help === true || parsed.flags.h === true;
   const versionFlag = parsed.flags.version === true;
 
-  const logger = createLogger(Boolean(verboseFlag));
+  let language: Language = "zh";
+  let translator = createTranslator(language);
+  let logger = createLogger(Boolean(verboseFlag), translator);
+
+  try {
+    const config = readConfig();
+    language = config.language;
+    translator = createTranslator(language);
+    logger = createLogger(Boolean(verboseFlag), translator);
+  } catch (error) {
+    if (error instanceof ConfigError) {
+      handleConfigError(error, logger, translator);
+    } else {
+      logger.error(
+        translator("errors.commandFailed", {
+          message: (error as Error).message,
+        })
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
   const context: CommandContext = {
     verbose: Boolean(verboseFlag),
     logger,
+    language,
+    t: translator,
   };
 
   if (versionFlag) {
@@ -156,14 +253,16 @@ async function main(): Promise<void> {
   }
 
   if (!parsed.commandName || helpFlag) {
-    showHelp();
+    showHelp(translator);
     return;
   }
 
   const command = findCommand(parsed.commandName);
   if (!command) {
-    logger.error(`未知命令：${parsed.commandName}`);
-    showHelp();
+    logger.error(
+      translator("errors.unknownCommand", { name: parsed.commandName })
+    );
+    showHelp(translator);
     process.exitCode = 1;
     return;
   }
@@ -179,7 +278,15 @@ async function main(): Promise<void> {
     }
     process.exitCode = result.code;
   } catch (error) {
-    logger.error(`命令执行失败：${(error as Error).message}`);
+    if (error instanceof ConfigError) {
+      handleConfigError(error, logger, translator);
+    } else {
+      logger.error(
+        translator("errors.commandFailed", {
+          message: (error as Error).message,
+        })
+      );
+    }
     if (context.verbose && error instanceof Error && error.stack) {
       logger.debug(error.stack);
     }
@@ -188,6 +295,13 @@ async function main(): Promise<void> {
 }
 
 main().catch((error) => {
-  console.error(red(`未捕获的错误：${(error as Error).message}`));
+  const fallbackTranslator = createTranslator("zh");
+  console.error(
+    red(
+      fallbackTranslator("errors.unhandled", {
+        message: (error as Error).message,
+      })
+    )
+  );
   process.exit(1);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 /**
  * 定义工具所需的核心类型与命令返回结构。
  */
+import type { Translator, Language } from "./i18n";
 import type { Logger } from "./utils/logger";
 
 export interface Project {
@@ -16,11 +17,14 @@ export interface CliTool {
 export interface AcsConfig {
   projects: Project[];
   cli: CliTool[];
+  language: Language;
 }
 
 export interface CommandContext {
   verbose: boolean;
   logger: Logger;
+  language: Language;
+  t: Translator;
 }
 
 export interface CliArguments {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,8 @@
 /**
  * 简单的日志封装，支持 verbose 控制详细输出。
  */
-import { bold, cyan, gray, red, yellow } from "colorette";
+import { cyan, gray, red, yellow } from "colorette";
+import type { Translator } from "../i18n";
 
 export interface Logger {
   info(message: string): void;
@@ -10,7 +11,7 @@ export interface Logger {
   debug(message: string): void;
 }
 
-export function createLogger(verbose: boolean): Logger {
+export function createLogger(verbose: boolean, translator: Translator): Logger {
   return {
     info(message: string) {
       console.log(cyan(message));
@@ -23,7 +24,9 @@ export function createLogger(verbose: boolean): Logger {
     },
     debug(message: string) {
       if (verbose) {
-        console.debug(gray(`[调试] ${message}`));
+        console.debug(
+          gray(`[${translator("logger.debugLabel")}] ${message}`)
+        );
       }
     },
   };

--- a/test/lang.test.ts
+++ b/test/lang.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runLang } from "../src/commands/lang";
+import { createLogger } from "../src/utils/logger";
+import { createTranslator } from "../src/i18n";
+import { readConfig } from "../src/config";
+
+describe("acs lang 命令", () => {
+  let tempHome: string;
+  let homedirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "acs-lang-"));
+    homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(tempHome);
+  });
+
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    fs.rmSync(tempHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("直接传入语言代码时应更新配置", async () => {
+    const translator = createTranslator("zh");
+    const logger = createLogger(false, translator);
+    const context = {
+      verbose: false,
+      logger,
+      language: "zh" as const,
+      t: translator,
+    };
+
+    const result = await runLang(
+      { flags: {}, positional: ["en"] },
+      context
+    );
+
+    expect(result.code).toBe(0);
+    const config = readConfig();
+    expect(config.language).toBe("en");
+  });
+
+  it("无效语言代码会返回错误", async () => {
+    const translator = createTranslator("zh");
+    const logger = createLogger(false, translator);
+    const errorSpy = vi.spyOn(logger, "error");
+
+    const result = await runLang(
+      { flags: {}, positional: ["fr"] },
+      {
+        verbose: false,
+        logger,
+        language: "zh",
+        t: translator,
+      }
+    );
+
+    expect(result.code).toBe(1);
+    expect(errorSpy).toHaveBeenCalled();
+    const config = readConfig();
+    expect(config.language).toBe("zh");
+  });
+});

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLogger } from "../src/utils/logger";
 import { getConfigPath, readConfig, writeConfig } from "../src/config";
 import { runList } from "../src/commands/list";
+import { createTranslator } from "../src/i18n";
 
 describe("acs CLI 鍐掔儫娴嬭瘯", () => {
   let tempHome: string;
@@ -24,11 +25,13 @@ describe("acs CLI 鍐掔儫娴嬭瘯", () => {
   });
 
   it("棣栨璇诲彇浼氬垱寤洪粯璁ら厤缃紝骞惰兘鍒楀嚭鏂板姞椤圭洰", async () => {
-    const logger = createLogger(false);
+    const translator = createTranslator("zh");
+    const logger = createLogger(false, translator);
     const config = readConfig();
     expect(Array.isArray(config.projects)).toBe(true);
+    expect(config.language).toBe("zh");
     expect(config.cli).toContainEqual({
-      name: "codex",
+      name: "CodeX",
       command: "codex",
     });
 
@@ -52,7 +55,7 @@ describe("acs CLI 鍐掔儫娴嬭瘯", () => {
 
     await runList(
       { flags: { json: true }, positional: [] },
-      { verbose: false, logger }
+      { verbose: false, logger, language: "zh", t: translator }
     );
 
     expect(logSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add an i18n layer with zh/en/ja message catalogues and persist the selected language in config
- localize existing commands, logger, and spawn output plus introduce the interactive `acs lang` command
- document the new language features across the README and expand automated tests for the language workflow

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb776acdf4832690764f4533fb44cf